### PR TITLE
Option to set vault package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
   description = "Helper for creating a Vault plugin directory";
 
   outputs = { ... }: {
-    lib.mkPluginDirectory = { plugins, pkgs }:
+    lib.mkPluginDirectory = { plugins, pkgs, vaultPackage ? pkgs.vault }:
       let
         inherit (builtins) map;
         inherit (pkgs.lib.meta) getExe;
@@ -64,7 +64,7 @@
           mkdir -p "$out/bin"
           echo ${escapeShellArg ("#!" + pkgs.runtimeShell)} > "$out/bin/${registerScriptName}"
           echo 'set -euo pipefail' >> "$out/bin/${registerScriptName}"
-          ${getExe scriptWriter} >> "$out/bin/${registerScriptName}"
+          ${getExe scriptWriter} -vault ${getExe (vaultPackage)} >> "$out/bin/${registerScriptName}"
           chmod +x "$out/bin/${registerScriptName}"
         '');
   };


### PR DESCRIPTION
Thanks for the simple an d great helper. 

I saw your go code has an option for the vault path. Though you were not using it and when running the resulting script, the vault binary is not found unless it's in the path. I think it's a great addition to add a way to specify the vault package to be used.